### PR TITLE
Refactor to support templates in alias files

### DIFF
--- a/cmd/we/main.go
+++ b/cmd/we/main.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 
 	"github.com/ionrock/we/envs"
-	"github.com/ionrock/we/toconfig"
 	"github.com/spf13/viper"
 
 	log "github.com/Sirupsen/logrus"
@@ -76,14 +75,6 @@ func WeAction(c *cli.Context) error {
 
 	for i, arg := range args {
 		parts[i] = os.ExpandEnv(arg)
-	}
-
-	if len(c.StringSlice("template")) > 0 {
-		err = toconfig.ApplyTemplates(c.StringSlice("template"))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing template: %q", err)
-			os.Exit(1)
-		}
 	}
 
 	cmd := exec.Command(parts[0], parts[1:]...)

--- a/envs/base.go
+++ b/envs/base.go
@@ -22,8 +22,6 @@ func ignore(flag string) bool {
 	ignored["-D"] = true
 	ignored["--clean"] = true
 	ignored["-c"] = true
-	ignored["--template"] = true
-	ignored["-t"] = true
 
 	_, ok := ignored[flag]
 	return ok
@@ -55,6 +53,8 @@ func pairs(args []string, path string) chan Action {
 					action = Dir{path: f}
 				case flag == "--alias" || flag == "-a":
 					action = Alias{path: f}
+				case flag == "--template" || flag == "-t":
+					action = Template{config: f}
 				default:
 					action = nil
 				}

--- a/toconfig/toconfig.go
+++ b/toconfig/toconfig.go
@@ -154,15 +154,24 @@ func parseTemplatePath(tmpl string) (*ConfigTmpl, error) {
 
 func ApplyTemplates(tmpls []string) error {
 	for _, tmpl := range tmpls {
-		conf, err := parseTemplatePath(tmpl)
-		if err != nil {
-			return err
-		}
-
-		err = conf.Execute()
+		err := ApplyTemplate(tmpl)
 		if err != nil {
 			return err
 		}
 	}
+	return nil
+}
+
+func ApplyTemplate(tmpl string) error {
+	conf, err := parseTemplatePath(tmpl)
+	if err != nil {
+		return err
+	}
+
+	err = conf.Execute()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
This makes a subtle change where the template is not automatically
rendered at the end of a run. I think this is OK b/c it is easy enough
for a user to add any template calls last as a best practice.

There is also the issue of how to clean things up afterwards, but
again, that can be a different flag that can show up in the alias /
base parser.