### PR TITLE
Add pluggable secret provider support

### DIFF
--- a/cmd/we/main.go
+++ b/cmd/we/main.go
@@ -32,29 +32,28 @@ func versionString() string {
 	return fmt.Sprintf("%s-%s", gitref, builddate)
 }
 
-func convertEnvForCmd(env map[string]string) []string {
-	envlist := []string{}
-	for key := range env {
-		if key != "" && os.Getenv(key) != "" {
-			envlist = append(envlist, fmt.Sprintf("%s=%s", key, os.Getenv(key)))
-		}
-	}
-
-	return envlist
+func convertEnvForCmd(env envs.Env) []string {
+	return env.Environ()
 }
 
-func mergeEnv(dst, src map[string]string) map[string]string {
+func mergeEnv(dst, src envs.Env) envs.Env {
 	if dst == nil {
-		dst = make(map[string]string)
+		dst = make(envs.Env)
 	}
-	for k, v := range src {
-		dst[k] = v
+	return dst.Merge(src)
+}
+
+func printEnv(env envs.Env, showSecrets bool) {
+	for _, line := range env.Lines(showSecrets) {
+		fmt.Println(line)
 	}
-	return dst
 }
 
 func WeAction(c *cli.Context) error {
 	InitLogging(c.Bool("debug"))
+	if c.Bool("agent") && c.Bool("show-secrets") {
+		return fmt.Errorf("--show-secrets cannot be used with --agent")
+	}
 
 	// Load .envrc-managed variables first so explicit we flags can override.
 	here, err := os.Getwd()
@@ -63,10 +62,11 @@ func WeAction(c *cli.Context) error {
 		os.Exit(1)
 	}
 
-	envrcEnv, err := envs.MaybeLoadEnvrc(here, c.Bool("no-direnv"))
+	envrcVals, err := envs.MaybeLoadEnvrc(here, c.Bool("no-direnv"))
 	if err != nil {
 		return err
 	}
+	envrcEnv := envs.EnvFromStringMap(envrcVals, ".envrc")
 
 	log.Debug().Msg("initializing config")
 	config, err := findConfig(".")
@@ -92,7 +92,7 @@ func WeAction(c *cli.Context) error {
 	// 1) ~/.withenv_global.yml (if present)
 	// 2) .envrc values
 	// 3) explicit withenv inputs (config alias + flags)
-	env := map[string]string{}
+	env := envs.Env{}
 
 	globalEnv, err := findGlobalEnv()
 	if err != nil {
@@ -100,7 +100,7 @@ func WeAction(c *cli.Context) error {
 	}
 	if globalEnv != "" {
 		log.Debug().Msgf("Loading global env: %s", globalEnv)
-		globalVals, err := envs.WithEnv([]string{"--env", globalEnv}, here)
+		globalVals, err := envs.WithEnvTyped([]string{"--env", globalEnv}, here)
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func WeAction(c *cli.Context) error {
 
 	env = mergeEnv(env, envrcEnv)
 
-	explicitEnv, err := envs.WithEnv(weargs, here)
+	explicitEnv, err := envs.WithEnvTypedFrom(weargs, here, env)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func WeAction(c *cli.Context) error {
 
 	log.Debug().Msg("Computed Env")
 	for k, v := range env {
-		log.Debug().Msgf("export %s=%s", k, v)
+		log.Debug().Msgf("export %s=%s", k, v.DisplayForKey(k, false))
 	}
 
 	if err != nil {
@@ -131,7 +131,8 @@ func WeAction(c *cli.Context) error {
 	parts := make([]string, args.Len())
 
 	if len(parts) == 0 {
-		parts = append(parts, "env")
+		printEnv(env, c.Bool("show-secrets"))
+		return nil
 	}
 
 	for i, arg := range args.Slice() {
@@ -423,6 +424,11 @@ func main() {
 			},
 
 			&cli.BoolFlag{
+				Name:  "show-secrets",
+				Usage: "Show secret values in no-command inspection output (disabled with --agent)",
+			},
+
+			&cli.BoolFlag{
 				Name:  "no-direnv",
 				Usage: "Disable automatic upward search and loading of .envrc",
 			},
@@ -456,5 +462,8 @@ func main() {
 		Action: WeAction,
 	}
 
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,9 @@
 
 Withenv (`we`) prefixes commands with an explicit environment loaded from YAML, JSON, scripts, directories, and aliases. It keeps project configuration repeatable without permanently changing your shell.
 
-The docs are organized into three sections:
+The docs are organized into four sections:
 
 1. [Quickstart](quickstart.md): create a simple `.withenv.yml` alias and `devenv.yml`, then prefix commands with `we`.
 2. [Reference](reference.md): every CLI flag and option, what it does, and when to use it.
-3. [Advanced usage](advanced.md): agent sandboxing, dynamic script sources, command substitution, and config templates.
+3. [Secrets](secrets.md): load secrets from 1Password, AWS Secrets Manager, and Bitwarden with redacted inspection output.
+4. [Advanced usage](advanced.md): agent sandboxing, dynamic script sources, command substitution, and config templates.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,7 +7,7 @@ we [global options] [COMMAND]
 we convert [command options] <input-file>
 ```
 
-If `COMMAND` is omitted, `we` runs `env` so you can inspect the computed environment.
+If `COMMAND` is omitted, `we` prints the computed environment so you can inspect it. Values known or inferred to be secret are redacted by default.
 
 ## How sources are applied
 
@@ -102,6 +102,10 @@ we --clean -e devenv.yml
 ```
 
 Use this to debug the exact environment withenv creates or to avoid accidental dependencies on your shell environment.
+
+### `--show-secrets`
+
+Shows secret values in no-command inspection output. This is disabled with `--agent`.
 
 ### `--no-direnv`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -237,7 +237,7 @@ This produces `DATABASE_HOST=localhost` and `HOSTS="app1 app2"`.
 YAML/JSON environment values can use `secret:` references. `we` resolves these before running the child command and redacts them in inspection output:
 
 ```yaml
-OPENAI_API_KEY: "secret:op://Private/api.openai.default.OPENAI_API_KEY/api key"
+PAYMENTS_API_KEY: "secret:op://Private/services.payments.dev/API key"
 DATABASE_PASSWORD: "secret:aws-secretsmanager://prod/my-app#database.password"
 OPTIONAL_TOKEN: "secret?:op://Private/my-app/optional-token"
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -232,6 +232,18 @@ hosts:
 
 This produces `DATABASE_HOST=localhost` and `HOSTS="app1 app2"`.
 
+### Secret references
+
+YAML/JSON environment values can use `secret:` references. `we` resolves these before running the child command and redacts them in inspection output:
+
+```yaml
+OPENAI_API_KEY: "secret:op://Private/api.openai.default.OPENAI_API_KEY/api key"
+DATABASE_PASSWORD: "secret:aws-secretsmanager://prod/my-app#database.password"
+OPTIONAL_TOKEN: "secret?:op://Private/my-app/optional-token"
+```
+
+`secret:` is required and fails if the provider lookup fails. `secret?:` is optional and omits the variable on failure. See [Secrets](secrets.md) for provider syntax, examples, and limitations.
+
 ## Automatic files
 
 ### `.withenv.yml`
@@ -262,3 +274,5 @@ source_env_if_exists local.env
 ```
 
 `.env` files are not auto-loaded by themselves. Add `dotenv` to `.envrc` when you want direnv-style `.env` loading. Disable `.envrc` behavior with `--no-direnv` or `WE_NO_DIRENV=1`.
+
+Secret provider refs are not resolved from `.envrc`, `.env`, or `source_env` files. Use withenv YAML/JSON sources, environment directories, scripts, `--envvar`, or `~/.withenv_global.yml` for `secret:` values.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,294 +1,177 @@
-# Secrets design
+# Secrets
 
-This document captures the planned design for first-class secret support in `we`.
-
-## Goals
-
-- Preserve metadata that a loaded value is secret.
-- Resolve secrets during environment loading so failures happen before the child command starts.
-- Keep the existing source model compatible with files, directories, scripts, aliases, templates, and `--envvar`.
-- Allow scripts and existing tools to emit secret references with minimal changes.
-- Make secret providers pluggable behind a small interface.
-- Redact secret values in `we`-controlled output and logs.
-
-## Non-goals for the first implementation
-
-- Prevent a child process from printing secrets it receives in its environment.
-- Redact arbitrary stdout/stderr from child commands.
-- Implement Kubernetes integration in v1.
-- Implement external executable provider plugins in v1.
-- Treat provider-looking URLs as secrets without an explicit marker.
-
-## Internal representation
-
-The current environment representation is effectively `map[string]string`. Secret support should first introduce a typed value representation, for example:
-
-```go
-type Value struct {
-    Value    string // resolved value used for env injection and templates
-    Raw      string // original configured value, e.g. secret:op://vault/item/field
-    Secret   bool
-    Resolved bool
-    Source   string // file path, script, envvar, provider URI, etc.
-    Provider string // literal, op, aws-secretsmanager, bitwarden, etc.
-}
-
-type Env map[string]Value
-```
-
-The final conversion to `KEY=value` strings should happen at the command execution boundary. This preserves metadata for redaction, inspection, templates, and future integrations.
+`we` can resolve secrets while it loads environment values. Secret values are passed to the child command as normal environment variables, but `we` tracks their metadata so inspection output and debug logs can redact them.
 
 ## Secret reference syntax
 
-Secret references are explicit scalar string values:
+Use a scalar string value prefixed with `secret:`:
 
 ```yaml
-PASSWORD: secret:op://Private/my-app/password
-OPTIONAL_TOKEN: secret?:op://Private/my-app/optional-token
+DATABASE_PASSWORD: "secret:op://Private/my-app/password"
+```
+
+Use `secret?:` for optional secrets. If resolution fails, the variable is omitted instead of aborting the command:
+
+```yaml
+OPTIONAL_TOKEN: "secret?:op://Private/my-app/optional-token"
 ```
 
 Rules:
 
-- `secret:<provider-uri>` is required. Resolution failure aborts loading.
-- `secret?:<provider-uri>` is optional. Resolution failure omits the variable.
-- Provider-looking URLs without `secret:` are literal strings.
-- This syntax works in files, directories, scripts, aliases, and `--envvar` values because it only relies on scalar value parsing.
+- `secret:` is required for provider resolution. A value that merely looks like `op://...` is treated as a literal string.
+- Required secret failures abort environment loading before the child command starts.
+- Optional secret failures omit that variable.
+- Secret refs work anywhere `we` loads scalar environment values through withenv sources: YAML/JSON files, environment directories, script output, and `--envvar` values.
+- Quote values in YAML when they contain spaces or characters that YAML might otherwise interpret.
 
-## Expansion and propagation
+## 1Password examples
 
-Values should be expanded before secret resolution:
-
-```yaml
-OP_VAULT: Private
-PASSWORD: secret:op://$OP_VAULT/my-app/password
-```
-
-If a later value expands a secret value, secrecy propagates:
+The `op` provider uses the 1Password CLI and reads the reference with `op read`.
 
 ```yaml
-PASSWORD: secret:op://Private/my-app/password
-DATABASE_URL: postgres://user:$PASSWORD@localhost/db
+OPENAI_API_KEY: "secret:op://Private/api.openai.default.OPENAI_API_KEY/api key"
+GEMINI_PROJECT_ID: "secret:op://Private/api.gemini.project.GEMINI_PROJECT_ID/project id"
 ```
 
-`DATABASE_URL` should be marked secret because it contains secret material.
-
-Implementation implication: replace direct `os.ExpandEnv` use in loading paths with a helper that returns both the expanded string and whether any referenced values were secret.
-
-## Redaction and display
-
-`we`-controlled logs and inspection output should redact secret values.
-
-When no command is provided, `we` should stop delegating to external `env` and instead print the computed environment itself so secrets can be redacted:
-
-```text
-APP_ENV=development
-DATABASE_PASSWORD=<redacted>
-DATABASE_URL=<redacted>
-```
-
-Add an explicit escape hatch:
+This resolves by running commands equivalent to:
 
 ```bash
-we --show-secrets
+op read 'op://Private/api.openai.default.OPENAI_API_KEY/api key'
+op read 'op://Private/api.gemini.project.GEMINI_PROJECT_ID/project id'
 ```
 
-In `--agent` mode, `--show-secrets` must be disabled. The command should either fail fast or ignore `--show-secrets` with a warning; failing fast is preferred.
+You can keep machine-wide secrets in `~/.withenv_global.yml`:
 
-`--agent` v1 boundary: child commands still receive resolved secrets and can print them. We will not attempt stdout/stderr redaction in v1.
-
-`--clean` semantics should remain unchanged. Without `--clean`, the child inherits the parent environment plus loaded values. With `--clean`, it receives only values loaded by `we`.
-
-## Templates
-
-Templates should render real secret values by default because templates are commonly used to create runtime config files required by the child command.
-
-`we` debug output should not log rendered secret values. Rendered template targets may contain secret material and should be treated as sensitive in documentation and future `--agent` sandbox improvements.
-
-## Provider interface
-
-Providers should be built-in Go implementations for v1, behind a small interface so external plugins can be added later.
-
-Example shape:
-
-```go
-type Provider interface {
-    Scheme() string
-    Resolve(ctx context.Context, ref Ref) (string, error)
-}
-
-type Ref struct {
-    Original string
-    Scheme   string
-    URL      *url.URL
-    Optional bool
-}
+```yaml title="~/.withenv_global.yml"
+---
+ANTHROPIC_API_KEY: "secret:op://Private/api.anthropic.default.ANTHROPIC_API_KEY/api key"
+OPENAI_API_KEY: "secret:op://Private/api.openai.default.OPENAI_API_KEY/api key"
+LINEAR_API_KEY: "secret:op://Private/api.linear.default.LINEAR_API_KEY/api key"
 ```
 
-Providers should shell out to existing CLIs in v1 where that matches user workflows and avoids reimplementing auth/session behavior.
+Or project-specific secrets in a file referenced by `.withenv.yml`:
 
-## Provider roadmap
-
-### Phase 1: 1Password
-
-Use the `op` CLI.
-
-Primary syntax:
-
-```yaml
-DATABASE_PASSWORD: secret:op://Private/my-app/password
+```yaml title=".withenv.yml"
+- file: secrets.yml
 ```
 
-Implementation should prefer:
-
-```bash
-op read op://Private/my-app/password
+```yaml title="secrets.yml"
+DATABASE_PASSWORD: "secret:op://Private/my-app/database-password"
 ```
 
-This reuses 1Password's own secret reference syntax and existing `op` authentication/session behavior.
+## AWS Secrets Manager examples
 
-### Phase 2: AWS Secrets Manager
-
-Use the `aws` CLI and support JSON field extraction.
-
-```yaml
-# Whole SecretString
-DATABASE_CONFIG: secret:aws-secretsmanager://prod/app
-
-# Top-level JSON key
-DATABASE_PASSWORD: secret:aws-secretsmanager://prod/app#password
-
-# Nested JSON path
-DATABASE_PASSWORD: secret:aws-secretsmanager://prod/app#database.password
-
-# Optional profile/region
-DATABASE_PASSWORD: secret:aws-secretsmanager://prod/app?profile=dev&region=us-west-2#database.password
-```
-
-Provider behavior should match the existing workflow:
+The `aws-secretsmanager` provider shells out to the AWS CLI:
 
 ```bash
 aws secretsmanager get-secret-value \
-  --secret-id prod/app \
+  --secret-id prod/my-app \
   --query SecretString \
   --output text
 ```
 
-Then:
-
-- no fragment returns the whole `SecretString`
-- a fragment parses `SecretString` as JSON and selects the dot path
-- missing paths fail for `secret:` and omit for `secret?:`
-
-This emulates workflows like:
-
-```bash
-aws secretsmanager get-secret-value ... | jq -r '.SecretString | fromjson | .path.to.value'
-```
-
-### Phase 3: Bitwarden
-
-Use the `bw` CLI.
+Use the whole `SecretString`:
 
 ```yaml
-BW_PASSWORD: secret:bitwarden://item-name#password
-BW_USERNAME: secret:bitwarden://item-name#username
-BW_NOTES: secret:bitwarden://item-name#notes
-BW_CUSTOM: secret:bitwarden://item-name#custom.my-field
+DATABASE_CONFIG: "secret:aws-secretsmanager://prod/my-app"
 ```
 
-Provider behavior:
-
-```bash
-bw get item "item-name"
-```
-
-Then parse JSON:
-
-- `#username` -> `.login.username`
-- `#password` -> `.login.password`
-- `#notes` -> `.notes`
-- `#custom.foo` -> custom field named `foo`
-
-### Later: Kubernetes
-
-A good later integration is loading existing Kubernetes Secret values locally:
+Select a field from a JSON `SecretString` with a fragment:
 
 ```yaml
-PASSWORD: secret:kubernetes://namespace/secret-name#key
+DATABASE_PASSWORD: "secret:aws-secretsmanager://prod/my-app#password"
+DATABASE_PASSWORD: "secret:aws-secretsmanager://prod/my-app#database.password"
 ```
 
-Provider behavior would shell out to `kubectl`:
+Pass profile or region as query parameters:
+
+```yaml
+DATABASE_PASSWORD: "secret:aws-secretsmanager://prod/my-app?profile=dev&region=us-west-2#database.password"
+```
+
+## Bitwarden examples
+
+The `bitwarden` provider shells out to `bw get item <item>` and extracts common fields:
+
+```yaml
+BW_USERNAME: "secret:bitwarden://my-login#username"
+BW_PASSWORD: "secret:bitwarden://my-login#password"
+BW_NOTES: "secret:bitwarden://my-login#notes"
+BW_API_KEY: "secret:bitwarden://my-login#custom.api-key"
+```
+
+## Expansion and propagation
+
+Values are expanded before secret resolution, so refs can reuse earlier environment values:
+
+```yaml
+OP_VAULT: Private
+DATABASE_PASSWORD: "secret:op://$OP_VAULT/my-app/database-password"
+```
+
+If a later value expands a secret value, the derived value is treated as secret too:
+
+```yaml
+DATABASE_PASSWORD: "secret:op://Private/my-app/database-password"
+DATABASE_URL: "postgres://app:$DATABASE_PASSWORD@localhost/app"
+```
+
+`DATABASE_URL` is redacted in `we` output because it contains `DATABASE_PASSWORD`.
+
+When ordering matters within one file, use a list of maps:
+
+```yaml
+---
+- OP_VAULT: Private
+- DATABASE_PASSWORD: "secret:op://$OP_VAULT/my-app/database-password"
+- DATABASE_URL: "postgres://app:$DATABASE_PASSWORD@localhost/app"
+```
+
+## Inspecting secret-loaded environments
+
+With no command, `we` prints the computed environment. Secret values are redacted by default:
 
 ```bash
-kubectl get secret secret-name -n namespace -o json
+we --clean
 ```
 
-Then read `.data[key]` and base64-decode it. This should be deferred until the core metadata model and initial providers are stable.
+```text
+DATABASE_PASSWORD=<redacted>
+DATABASE_URL=<redacted>
+```
 
-Other Kubernetes opportunities, also deferred:
+Use `--show-secrets` to inspect actual values:
 
-- generate Kubernetes `Secret` manifests from a computed `we` environment
-- generate `envFrom` / `secretRef` deployment snippets
-- improve `--agent` sandbox behavior around generated secret-bearing files
+```bash
+we --show-secrets --clean
+```
 
-## Testing strategy
+`--show-secrets` cannot be used with `--agent`.
 
-### Representation and compatibility tests
+## Using secrets from `--envvar` and scripts
 
-- Existing YAML/JSON flattening behavior remains unchanged for ordinary scalar and nested values.
-- Existing `file`, `directory`, `script`, `envvar`, `alias`, and `template` tests continue to pass.
-- Values without `secret:` remain non-secret, including literal strings that look like provider URLs.
-- `secret:` and `secret?:` markers are recognized from all scalar-producing sources.
+One-off secret refs work with `--envvar`:
 
-### Expansion tests
+```bash
+we --envvar 'OPENAI_API_KEY=secret:op://Private/api.openai.default.OPENAI_API_KEY/api key' your-command
+```
 
-- Secret URIs expand environment variables before provider resolution.
-- Values derived from secret values are marked secret.
-- Values derived only from non-secret values remain non-secret.
-- Expansion order and override precedence match current behavior.
+Scripts can emit YAML or JSON containing secret refs. `we` resolves them after the script output is parsed:
 
-### Optional secret tests
+```bash
+we --script './print-secret-refs' your-command
+```
 
-- Required secret resolution failure aborts loading.
-- Optional secret resolution failure omits the variable.
-- Optional omission does not override an existing value in the computed environment.
+Example script output:
 
-### Redaction tests
+```yaml
+API_TOKEN: "secret:op://Private/my-app/api-token"
+```
 
-- Debug logs redact values marked secret.
-- No-command output redacts secrets by default.
-- `--show-secrets` prints real values outside `--agent` mode.
-- `--agent --show-secrets` fails fast.
-- Child command output is not redacted in v1; document this boundary with a test or explicit fixture if practical.
+## Limitations
 
-### Provider tests
-
-Provider tests should avoid real secret manager dependencies by using fake CLIs placed earlier in `PATH`.
-
-1Password fake `op`:
-
-- Assert `op read op://...` is invoked with the expected reference.
-- Return a known value and verify it becomes a secret `Value`.
-- Return non-zero and verify required vs optional behavior.
-
-AWS Secrets Manager fake `aws`:
-
-- Assert `aws secretsmanager get-secret-value --secret-id ... --query SecretString --output text` is invoked.
-- Verify `profile` and `region` query params become CLI flags.
-- Return a plain string and verify whole-secret extraction.
-- Return JSON and verify `#topLevel` and `#nested.path` extraction.
-- Verify missing JSON path behavior for required and optional refs.
-- Verify malformed JSON with a fragment fails clearly.
-
-Bitwarden fake `bw`:
-
-- Assert `bw get item <item>` is invoked.
-- Return item JSON and verify `#username`, `#password`, `#notes`, and `#custom.name` extraction.
-- Verify missing fields for required and optional refs.
-
-### Integration-style tests
-
-- Script source can emit `PASSWORD: secret:op://...` and the resulting value is resolved and marked secret.
-- `--envvar PASSWORD=secret:op://...` resolves and marks secret.
-- Template rendering receives real values while `we` logs/inspection redact them.
-- `--clean` preserves existing behavior with typed values converted at the boundary.
+- `.envrc`, `.env`, and `source_env` files are parsed for literal assignments only. Secret provider refs in these direnv-style files are not currently resolved; they will be passed through as literal strings. Use a withenv YAML/JSON file, environment directory, script source, `--envvar`, or `~/.withenv_global.yml` for secret refs.
+- A top-level `secrets:` section has no special meaning. Nested YAML is flattened into env var names, so put secret refs directly under the env var names you want to set.
+- `we` redacts its own inspection and debug output, but it cannot prevent the child process from printing secrets it receives in the environment.
+- Provider CLIs must be installed and authenticated before `we` runs (`op`, `aws`, or `bw`). `we` reuses those tools' existing auth/session behavior.
+- Provider-looking values without `secret:` are literals by design.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,294 @@
+# Secrets design
+
+This document captures the planned design for first-class secret support in `we`.
+
+## Goals
+
+- Preserve metadata that a loaded value is secret.
+- Resolve secrets during environment loading so failures happen before the child command starts.
+- Keep the existing source model compatible with files, directories, scripts, aliases, templates, and `--envvar`.
+- Allow scripts and existing tools to emit secret references with minimal changes.
+- Make secret providers pluggable behind a small interface.
+- Redact secret values in `we`-controlled output and logs.
+
+## Non-goals for the first implementation
+
+- Prevent a child process from printing secrets it receives in its environment.
+- Redact arbitrary stdout/stderr from child commands.
+- Implement Kubernetes integration in v1.
+- Implement external executable provider plugins in v1.
+- Treat provider-looking URLs as secrets without an explicit marker.
+
+## Internal representation
+
+The current environment representation is effectively `map[string]string`. Secret support should first introduce a typed value representation, for example:
+
+```go
+type Value struct {
+    Value    string // resolved value used for env injection and templates
+    Raw      string // original configured value, e.g. secret:op://vault/item/field
+    Secret   bool
+    Resolved bool
+    Source   string // file path, script, envvar, provider URI, etc.
+    Provider string // literal, op, aws-secretsmanager, bitwarden, etc.
+}
+
+type Env map[string]Value
+```
+
+The final conversion to `KEY=value` strings should happen at the command execution boundary. This preserves metadata for redaction, inspection, templates, and future integrations.
+
+## Secret reference syntax
+
+Secret references are explicit scalar string values:
+
+```yaml
+PASSWORD: secret:op://Private/my-app/password
+OPTIONAL_TOKEN: secret?:op://Private/my-app/optional-token
+```
+
+Rules:
+
+- `secret:<provider-uri>` is required. Resolution failure aborts loading.
+- `secret?:<provider-uri>` is optional. Resolution failure omits the variable.
+- Provider-looking URLs without `secret:` are literal strings.
+- This syntax works in files, directories, scripts, aliases, and `--envvar` values because it only relies on scalar value parsing.
+
+## Expansion and propagation
+
+Values should be expanded before secret resolution:
+
+```yaml
+OP_VAULT: Private
+PASSWORD: secret:op://$OP_VAULT/my-app/password
+```
+
+If a later value expands a secret value, secrecy propagates:
+
+```yaml
+PASSWORD: secret:op://Private/my-app/password
+DATABASE_URL: postgres://user:$PASSWORD@localhost/db
+```
+
+`DATABASE_URL` should be marked secret because it contains secret material.
+
+Implementation implication: replace direct `os.ExpandEnv` use in loading paths with a helper that returns both the expanded string and whether any referenced values were secret.
+
+## Redaction and display
+
+`we`-controlled logs and inspection output should redact secret values.
+
+When no command is provided, `we` should stop delegating to external `env` and instead print the computed environment itself so secrets can be redacted:
+
+```text
+APP_ENV=development
+DATABASE_PASSWORD=<redacted>
+DATABASE_URL=<redacted>
+```
+
+Add an explicit escape hatch:
+
+```bash
+we --show-secrets
+```
+
+In `--agent` mode, `--show-secrets` must be disabled. The command should either fail fast or ignore `--show-secrets` with a warning; failing fast is preferred.
+
+`--agent` v1 boundary: child commands still receive resolved secrets and can print them. We will not attempt stdout/stderr redaction in v1.
+
+`--clean` semantics should remain unchanged. Without `--clean`, the child inherits the parent environment plus loaded values. With `--clean`, it receives only values loaded by `we`.
+
+## Templates
+
+Templates should render real secret values by default because templates are commonly used to create runtime config files required by the child command.
+
+`we` debug output should not log rendered secret values. Rendered template targets may contain secret material and should be treated as sensitive in documentation and future `--agent` sandbox improvements.
+
+## Provider interface
+
+Providers should be built-in Go implementations for v1, behind a small interface so external plugins can be added later.
+
+Example shape:
+
+```go
+type Provider interface {
+    Scheme() string
+    Resolve(ctx context.Context, ref Ref) (string, error)
+}
+
+type Ref struct {
+    Original string
+    Scheme   string
+    URL      *url.URL
+    Optional bool
+}
+```
+
+Providers should shell out to existing CLIs in v1 where that matches user workflows and avoids reimplementing auth/session behavior.
+
+## Provider roadmap
+
+### Phase 1: 1Password
+
+Use the `op` CLI.
+
+Primary syntax:
+
+```yaml
+DATABASE_PASSWORD: secret:op://Private/my-app/password
+```
+
+Implementation should prefer:
+
+```bash
+op read op://Private/my-app/password
+```
+
+This reuses 1Password's own secret reference syntax and existing `op` authentication/session behavior.
+
+### Phase 2: AWS Secrets Manager
+
+Use the `aws` CLI and support JSON field extraction.
+
+```yaml
+# Whole SecretString
+DATABASE_CONFIG: secret:aws-secretsmanager://prod/app
+
+# Top-level JSON key
+DATABASE_PASSWORD: secret:aws-secretsmanager://prod/app#password
+
+# Nested JSON path
+DATABASE_PASSWORD: secret:aws-secretsmanager://prod/app#database.password
+
+# Optional profile/region
+DATABASE_PASSWORD: secret:aws-secretsmanager://prod/app?profile=dev&region=us-west-2#database.password
+```
+
+Provider behavior should match the existing workflow:
+
+```bash
+aws secretsmanager get-secret-value \
+  --secret-id prod/app \
+  --query SecretString \
+  --output text
+```
+
+Then:
+
+- no fragment returns the whole `SecretString`
+- a fragment parses `SecretString` as JSON and selects the dot path
+- missing paths fail for `secret:` and omit for `secret?:`
+
+This emulates workflows like:
+
+```bash
+aws secretsmanager get-secret-value ... | jq -r '.SecretString | fromjson | .path.to.value'
+```
+
+### Phase 3: Bitwarden
+
+Use the `bw` CLI.
+
+```yaml
+BW_PASSWORD: secret:bitwarden://item-name#password
+BW_USERNAME: secret:bitwarden://item-name#username
+BW_NOTES: secret:bitwarden://item-name#notes
+BW_CUSTOM: secret:bitwarden://item-name#custom.my-field
+```
+
+Provider behavior:
+
+```bash
+bw get item "item-name"
+```
+
+Then parse JSON:
+
+- `#username` -> `.login.username`
+- `#password` -> `.login.password`
+- `#notes` -> `.notes`
+- `#custom.foo` -> custom field named `foo`
+
+### Later: Kubernetes
+
+A good later integration is loading existing Kubernetes Secret values locally:
+
+```yaml
+PASSWORD: secret:kubernetes://namespace/secret-name#key
+```
+
+Provider behavior would shell out to `kubectl`:
+
+```bash
+kubectl get secret secret-name -n namespace -o json
+```
+
+Then read `.data[key]` and base64-decode it. This should be deferred until the core metadata model and initial providers are stable.
+
+Other Kubernetes opportunities, also deferred:
+
+- generate Kubernetes `Secret` manifests from a computed `we` environment
+- generate `envFrom` / `secretRef` deployment snippets
+- improve `--agent` sandbox behavior around generated secret-bearing files
+
+## Testing strategy
+
+### Representation and compatibility tests
+
+- Existing YAML/JSON flattening behavior remains unchanged for ordinary scalar and nested values.
+- Existing `file`, `directory`, `script`, `envvar`, `alias`, and `template` tests continue to pass.
+- Values without `secret:` remain non-secret, including literal strings that look like provider URLs.
+- `secret:` and `secret?:` markers are recognized from all scalar-producing sources.
+
+### Expansion tests
+
+- Secret URIs expand environment variables before provider resolution.
+- Values derived from secret values are marked secret.
+- Values derived only from non-secret values remain non-secret.
+- Expansion order and override precedence match current behavior.
+
+### Optional secret tests
+
+- Required secret resolution failure aborts loading.
+- Optional secret resolution failure omits the variable.
+- Optional omission does not override an existing value in the computed environment.
+
+### Redaction tests
+
+- Debug logs redact values marked secret.
+- No-command output redacts secrets by default.
+- `--show-secrets` prints real values outside `--agent` mode.
+- `--agent --show-secrets` fails fast.
+- Child command output is not redacted in v1; document this boundary with a test or explicit fixture if practical.
+
+### Provider tests
+
+Provider tests should avoid real secret manager dependencies by using fake CLIs placed earlier in `PATH`.
+
+1Password fake `op`:
+
+- Assert `op read op://...` is invoked with the expected reference.
+- Return a known value and verify it becomes a secret `Value`.
+- Return non-zero and verify required vs optional behavior.
+
+AWS Secrets Manager fake `aws`:
+
+- Assert `aws secretsmanager get-secret-value --secret-id ... --query SecretString --output text` is invoked.
+- Verify `profile` and `region` query params become CLI flags.
+- Return a plain string and verify whole-secret extraction.
+- Return JSON and verify `#topLevel` and `#nested.path` extraction.
+- Verify missing JSON path behavior for required and optional refs.
+- Verify malformed JSON with a fragment fails clearly.
+
+Bitwarden fake `bw`:
+
+- Assert `bw get item <item>` is invoked.
+- Return item JSON and verify `#username`, `#password`, `#notes`, and `#custom.name` extraction.
+- Verify missing fields for required and optional refs.
+
+### Integration-style tests
+
+- Script source can emit `PASSWORD: secret:op://...` and the resulting value is resolved and marked secret.
+- `--envvar PASSWORD=secret:op://...` resolves and marks secret.
+- Template rendering receives real values while `we` logs/inspection redact them.
+- `--clean` preserves existing behavior with typed values converted at the boundary.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -29,24 +29,25 @@ Rules:
 The `op` provider uses the 1Password CLI and reads the reference with `op read`.
 
 ```yaml
-OPENAI_API_KEY: "secret:op://Private/api.openai.default.OPENAI_API_KEY/api key"
-GEMINI_PROJECT_ID: "secret:op://Private/api.gemini.project.GEMINI_PROJECT_ID/project id"
+PAYMENTS_API_KEY: "secret:op://Private/services.payments.dev/API key"
+SUPPORT_API_TOKEN: "secret:op://Private/services.support.dev/API token"
 ```
+
+These examples assume 1Password secure note items named `services.payments.dev` and `services.support.dev`, with note fields named `API key` and `API token`.
 
 This resolves by running commands equivalent to:
 
 ```bash
-op read 'op://Private/api.openai.default.OPENAI_API_KEY/api key'
-op read 'op://Private/api.gemini.project.GEMINI_PROJECT_ID/project id'
+op read 'op://Private/services.payments.dev/API key'
+op read 'op://Private/services.support.dev/API token'
 ```
 
 You can keep machine-wide secrets in `~/.withenv_global.yml`:
 
 ```yaml title="~/.withenv_global.yml"
 ---
-ANTHROPIC_API_KEY: "secret:op://Private/api.anthropic.default.ANTHROPIC_API_KEY/api key"
-OPENAI_API_KEY: "secret:op://Private/api.openai.default.OPENAI_API_KEY/api key"
-LINEAR_API_KEY: "secret:op://Private/api.linear.default.LINEAR_API_KEY/api key"
+PAYMENTS_API_KEY: "secret:op://Private/services.payments.dev/API key"
+SUPPORT_API_TOKEN: "secret:op://Private/services.support.dev/API token"
 ```
 
 Or project-specific secrets in a file referenced by `.withenv.yml`:
@@ -153,7 +154,7 @@ we --show-secrets --clean
 One-off secret refs work with `--envvar`:
 
 ```bash
-we --envvar 'OPENAI_API_KEY=secret:op://Private/api.openai.default.OPENAI_API_KEY/api key' your-command
+we --envvar 'PAYMENTS_API_KEY=secret:op://Private/services.payments.dev/API key' your-command
 ```
 
 Scripts can emit YAML or JSON containing secret refs. `we` resolves them after the script output is parsed:

--- a/envs/alias.go
+++ b/envs/alias.go
@@ -38,7 +38,7 @@ func (alias Alias) loadEntry(k, v string) (string, string) {
 	return fmt.Sprintf("--%s", k), v
 }
 
-func (alias Alias) ApplyFromMap(entries []map[string]string) (map[string]string, error) {
+func (alias Alias) ApplyFromMap(entries []map[string]string, cur Env) (Env, error) {
 	args := []string{}
 
 	for _, e := range entries {
@@ -50,10 +50,14 @@ func (alias Alias) ApplyFromMap(entries []map[string]string) (map[string]string,
 
 	log.Debug().Msgf("Loaded alias %s with: %v", alias.path, args)
 
-	return WithEnv(args, filepath.Dir(alias.path))
+	env, err := WithEnvTypedFrom(args, filepath.Dir(alias.path), cur)
+	if err != nil {
+		return nil, err
+	}
+	return make(Env).Merge(cur).Merge(env), nil
 }
 
-func (alias Alias) Apply() (map[string]string, error) {
+func (alias Alias) Apply(cur Env) (Env, error) {
 	log.Debug().Msgf("Reading: %s", alias.path)
 	b, err := os.ReadFile(alias.path)
 	if err != nil {
@@ -80,7 +84,7 @@ func (alias Alias) Apply() (map[string]string, error) {
 		}
 	}
 
-	env, err := alias.ApplyFromMap(entries)
+	env, err := alias.ApplyFromMap(entries, cur)
 	if err != nil {
 		return nil, err
 	}

--- a/envs/base.go
+++ b/envs/base.go
@@ -5,14 +5,7 @@ import (
 )
 
 type Action interface {
-	Apply() (map[string]string, error)
-}
-
-func updateEnvMap(cur, env map[string]string) map[string]string {
-	for k, v := range env {
-		cur[k] = v
-	}
-	return cur
+	Apply(cur Env) (Env, error)
 }
 
 func ignore(flag string) bool {
@@ -25,6 +18,7 @@ func ignore(flag string) bool {
 	ignored["--no-direnv"] = true
 	ignored["--agent"] = true
 	ignored["--sandbox-deny-network"] = true
+	ignored["--show-secrets"] = true
 
 	_, ok := ignored[flag]
 	return ok
@@ -81,17 +75,32 @@ func pairs(args []string, path string) chan Action {
 	return p
 }
 
-func WithEnv(args []string, path string) (map[string]string, error) {
-	env := make(map[string]string)
+func WithEnvTyped(args []string, path string) (Env, error) {
+	return WithEnvTypedFrom(args, path, nil)
+}
+
+func WithEnvTypedFrom(args []string, path string, initial Env) (Env, error) {
+	env := make(Env)
+	if initial != nil {
+		env = env.Merge(initial)
+	}
 
 	for action := range pairs(args, path) {
 		log.Debug().Msgf("Applying action: %#v", action)
-		newEnv, err := action.Apply()
+		newEnv, err := action.Apply(env)
 		if err != nil {
 			return nil, err
 		}
-		env = updateEnvMap(env, newEnv)
+		env = env.Merge(newEnv)
 	}
 
 	return env, nil
+}
+
+func WithEnv(args []string, path string) (map[string]string, error) {
+	env, err := WithEnvTyped(args, path)
+	if err != nil {
+		return nil, err
+	}
+	return env.StringMap(), nil
 }

--- a/envs/dir.go
+++ b/envs/dir.go
@@ -32,16 +32,18 @@ func (e Dir) Files() chan string {
 	return files
 }
 
-func (e Dir) Apply() (map[string]string, error) {
-	env := make(map[string]string)
+func (e Dir) Apply(cur Env) (Env, error) {
+	env := make(Env)
+	working := make(Env).Merge(cur)
 
 	for fn := range e.Files() {
 		ef := File{fn}
-		newEnv, err := ef.Apply()
+		newEnv, err := ef.Apply(working)
 		if err != nil {
 			return nil, err
 		}
-		env = updateEnvMap(env, newEnv)
+		env = env.Merge(newEnv)
+		working = working.Merge(newEnv)
 	}
 
 	return env, nil

--- a/envs/file.go
+++ b/envs/file.go
@@ -1,6 +1,7 @@
 package envs
 
 import (
+	"context"
 	"os"
 
 	"github.com/ionrock/we/flat"
@@ -20,16 +21,47 @@ func (e File) Parse() (map[string]string, error) {
 	return env, nil
 }
 
-func (e File) Apply() (map[string]string, error) {
-	env, err := e.Parse()
+func (e File) parseWithOrder() (map[string]string, []string, error) {
+	env, order, err := flat.NewFlatEnvWithOrder(e.path)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to parse flat environment")
+	}
+	return env, order, nil
+}
+
+func (e File) Apply(cur Env) (Env, error) {
+	parsed, order, err := e.parseWithOrder()
 	if err != nil {
 		return nil, err
 	}
 
-	for k, v := range env {
-		log.Debug().Msgf("Setting: %s to %s", k, os.ExpandEnv(v))
-		err = os.Setenv(k, os.ExpandEnv(v))
-		if err != nil {
+	env := make(Env, len(parsed))
+	providers := DefaultProviders()
+	working := make(Env).Merge(cur)
+	for _, k := range order {
+		raw := parsed[k]
+		expanded, usedSecret := expandValue(raw, working)
+		if ref, optional, ok := isSecretRef(expanded); ok {
+			value, include, err := providers.Resolve(context.Background(), ref, optional)
+			if err != nil {
+				return nil, err
+			}
+			if !include {
+				continue
+			}
+			value.Raw = raw
+			value.Source = e.path
+			env[k] = value
+			working[k] = value
+		} else {
+			value := NewLiteralValue(expanded, e.path)
+			value.Raw = raw
+			value.Secret = usedSecret || LooksSensitiveName(k)
+			env[k] = value
+			working[k] = value
+		}
+		log.Debug().Msgf("Setting: %s to %s", k, env[k].DisplayForKey(k, false))
+		if err = os.Setenv(k, env[k].Value); err != nil {
 			return nil, err
 		}
 	}

--- a/envs/providers.go
+++ b/envs/providers.go
@@ -1,0 +1,203 @@
+package envs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+type SecretRef struct {
+	Original string
+	Scheme   string
+	URL      *url.URL
+	Optional bool
+}
+
+type Provider interface {
+	Scheme() string
+	Resolve(ctx context.Context, ref SecretRef) (string, error)
+}
+
+type ProviderRegistry map[string]Provider
+
+func DefaultProviders() ProviderRegistry {
+	providers := []Provider{
+		OPProvider{},
+		AWSSecretsManagerProvider{},
+		BitwardenProvider{},
+	}
+	registry := make(ProviderRegistry, len(providers))
+	for _, provider := range providers {
+		registry[provider.Scheme()] = provider
+	}
+	return registry
+}
+
+func (r ProviderRegistry) Resolve(ctx context.Context, raw string, optional bool) (Value, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return Value{}, false, err
+	}
+	provider, ok := r[u.Scheme]
+	if !ok {
+		return Value{}, false, fmt.Errorf("unsupported secret provider %q", u.Scheme)
+	}
+	resolved, err := provider.Resolve(ctx, SecretRef{Original: raw, Scheme: u.Scheme, URL: u, Optional: optional})
+	if err != nil {
+		if optional {
+			return Value{}, false, nil
+		}
+		return Value{}, false, err
+	}
+	return Value{Value: resolved, Raw: "secret:" + raw, Secret: true, Resolved: true, Provider: u.Scheme}, true, nil
+}
+
+type OPProvider struct{}
+
+func (OPProvider) Scheme() string { return "op" }
+
+func (OPProvider) Resolve(ctx context.Context, ref SecretRef) (string, error) {
+	cmd := exec.CommandContext(ctx, "op", "read", ref.Original)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
+}
+
+type AWSSecretsManagerProvider struct{}
+
+func (AWSSecretsManagerProvider) Scheme() string { return "aws-secretsmanager" }
+
+func (AWSSecretsManagerProvider) Resolve(ctx context.Context, ref SecretRef) (string, error) {
+	secretID := strings.TrimPrefix(ref.URL.Path, "/")
+	if ref.URL.Host != "" {
+		if secretID == "" {
+			secretID = ref.URL.Host
+		} else {
+			secretID = ref.URL.Host + "/" + secretID
+		}
+	}
+	if secretID == "" {
+		return "", errors.New("aws-secretsmanager secret id is required")
+	}
+
+	args := []string{"secretsmanager", "get-secret-value", "--secret-id", secretID, "--query", "SecretString", "--output", "text"}
+	q := ref.URL.Query()
+	if profile := q.Get("profile"); profile != "" {
+		args = append(args, "--profile", profile)
+	}
+	if region := q.Get("region"); region != "" {
+		args = append(args, "--region", region)
+	}
+
+	cmd := exec.CommandContext(ctx, "aws", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	secretString := strings.TrimRight(string(out), "\r\n")
+	if ref.URL.Fragment == "" {
+		return secretString, nil
+	}
+	return selectJSONPath(secretString, ref.URL.Fragment)
+}
+
+type BitwardenProvider struct{}
+
+func (BitwardenProvider) Scheme() string { return "bitwarden" }
+
+func (BitwardenProvider) Resolve(ctx context.Context, ref SecretRef) (string, error) {
+	item := strings.TrimPrefix(ref.URL.Path, "/")
+	if ref.URL.Host != "" {
+		if item == "" {
+			item = ref.URL.Host
+		} else {
+			item = ref.URL.Host + "/" + item
+		}
+	}
+	if item == "" {
+		return "", errors.New("bitwarden item is required")
+	}
+	cmd := exec.CommandContext(ctx, "bw", "get", "item", item)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return selectBitwardenField(out, ref.URL.Fragment)
+}
+
+func selectJSONPath(input string, path string) (string, error) {
+	var cur interface{}
+	if err := json.Unmarshal([]byte(input), &cur); err != nil {
+		return "", fmt.Errorf("secret value is not valid JSON: %w", err)
+	}
+	for _, part := range strings.Split(path, ".") {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("JSON path %q not found", path)
+		}
+		cur, ok = m[part]
+		if !ok {
+			return "", fmt.Errorf("JSON path %q not found", path)
+		}
+	}
+	switch v := cur.(type) {
+	case string:
+		return v, nil
+	case float64, bool:
+		return fmt.Sprintf("%v", v), nil
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+}
+
+func selectBitwardenField(input []byte, field string) (string, error) {
+	var item map[string]interface{}
+	if err := json.Unmarshal(input, &item); err != nil {
+		return "", err
+	}
+	switch field {
+	case "username", "password":
+		login, ok := item["login"].(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("bitwarden login field %q not found", field)
+		}
+		v, ok := login[field].(string)
+		if !ok {
+			return "", fmt.Errorf("bitwarden field %q not found", field)
+		}
+		return v, nil
+	case "notes":
+		v, ok := item["notes"].(string)
+		if !ok {
+			return "", errors.New("bitwarden notes field not found")
+		}
+		return v, nil
+	default:
+		if strings.HasPrefix(field, "custom.") {
+			name := strings.TrimPrefix(field, "custom.")
+			fields, _ := item["fields"].([]interface{})
+			for _, rawField := range fields {
+				m, ok := rawField.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if m["name"] == name {
+					if v, ok := m["value"].(string); ok {
+						return v, nil
+					}
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("bitwarden field %q not found", field)
+}

--- a/envs/script.go
+++ b/envs/script.go
@@ -12,7 +12,7 @@ type Script struct {
 	dir string
 }
 
-func (e Script) Apply() (map[string]string, error) {
+func (e Script) Apply(cur Env) (Env, error) {
 	proc := process.New(e.cmd, e.dir)
 
 	buf, err := proc.Execute()
@@ -30,5 +30,5 @@ func (e Script) Apply() (map[string]string, error) {
 	tmp.Close()
 
 	ef := File{path: tmp.Name()}
-	return ef.Apply()
+	return ef.Apply(cur)
 }

--- a/envs/secrets_test.go
+++ b/envs/secrets_test.go
@@ -1,0 +1,114 @@
+package envs
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func writeExecutable(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("write fake executable: %v", err)
+	}
+}
+
+func TestSecretOPProviderAndRedaction(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "op", "#!/bin/sh\necho op-secret\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	path := filepath.Join(dir, "env.yml")
+	if err := os.WriteFile(path, []byte("PASSWORD: secret:op://Private/app/password\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := WithEnvTyped([]string{"--env", path}, dir)
+	if err != nil {
+		t.Fatalf("WithEnvTyped failed: %v", err)
+	}
+	if env["PASSWORD"].Value != "op-secret" || !env["PASSWORD"].Secret {
+		t.Fatalf("expected resolved secret, got %#v", env["PASSWORD"])
+	}
+	if got := env.Lines(false)[0]; got != "PASSWORD=<redacted>" {
+		t.Fatalf("expected redacted line, got %q", got)
+	}
+}
+
+func TestOptionalSecretOmittedOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "op", "#!/bin/sh\nexit 1\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	path := filepath.Join(dir, "env.yml")
+	if err := os.WriteFile(path, []byte("TOKEN: secret?:op://Private/app/missing\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	env, err := WithEnvTyped([]string{"--env", path}, dir)
+	if err != nil {
+		t.Fatalf("optional secret should not fail: %v", err)
+	}
+	if _, ok := env["TOKEN"]; ok {
+		t.Fatalf("optional failed secret should be omitted: %#v", env)
+	}
+}
+
+func TestSecretExpansionPropagates(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "op", "#!/bin/sh\necho pass\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	path := filepath.Join(dir, "env.yml")
+	content := "- PASSWORD: secret:op://Private/app/password\n- DATABASE_URL: postgres://user:$PASSWORD@localhost/db\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	env, err := WithEnvTyped([]string{"--env", path}, dir)
+	if err != nil {
+		t.Fatalf("WithEnvTyped failed: %v", err)
+	}
+	if env["DATABASE_URL"].Value != "postgres://user:pass@localhost/db" || !env["DATABASE_URL"].Secret {
+		t.Fatalf("expected secret-derived database url, got %#v", env["DATABASE_URL"])
+	}
+}
+
+func TestAWSSecretsManagerJSONPath(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "aws", "#!/bin/sh\necho '{\"database\":{\"password\":\"aws-secret\"}}'\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	path := filepath.Join(dir, "env.yml")
+	if err := os.WriteFile(path, []byte("PASSWORD: secret:aws-secretsmanager://prod/app?profile=dev&region=us-west-2#database.password\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	env, err := WithEnvTyped([]string{"--env", path}, dir)
+	if err != nil {
+		t.Fatalf("WithEnvTyped failed: %v", err)
+	}
+	if env["PASSWORD"].Value != "aws-secret" || !env["PASSWORD"].Secret {
+		t.Fatalf("expected aws secret, got %#v", env["PASSWORD"])
+	}
+}
+
+func TestBitwardenFields(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "bw", "#!/bin/sh\necho '{\"login\":{\"username\":\"u\",\"password\":\"p\"},\"notes\":\"n\",\"fields\":[{\"name\":\"api\",\"value\":\"key\"}]}'\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	path := filepath.Join(dir, "env.yml")
+	if err := os.WriteFile(path, []byte("API_KEY: secret:bitwarden://my-item#custom.api\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	env, err := WithEnvTyped([]string{"--env", path}, dir)
+	if err != nil {
+		t.Fatalf("WithEnvTyped failed: %v", err)
+	}
+	if env["API_KEY"].Value != "key" || !env["API_KEY"].Secret {
+		t.Fatalf("expected bitwarden secret, got %#v", env["API_KEY"])
+	}
+}

--- a/envs/template.go
+++ b/envs/template.go
@@ -11,7 +11,7 @@ type Template struct {
 	config string
 }
 
-func (t Template) Apply() (map[string]string, error) {
+func (t Template) Apply(cur Env) (Env, error) {
 	err := toconfig.ApplyTemplate(t.config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing template: %q", err)

--- a/envs/value.go
+++ b/envs/value.go
@@ -1,0 +1,136 @@
+package envs
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const RedactedValue = "<redacted>"
+
+type Value struct {
+	Value    string
+	Raw      string
+	Secret   bool
+	Resolved bool
+	Source   string
+	Provider string
+}
+
+type Env map[string]Value
+
+func NewLiteralValue(value, source string) Value {
+	return Value{Value: value, Raw: value, Resolved: true, Source: source, Provider: "literal"}
+}
+
+func EnvFromStringMap(values map[string]string, source string) Env {
+	env := make(Env, len(values))
+	for k, v := range values {
+		value := NewLiteralValue(v, source)
+		value.Secret = LooksSensitiveName(k)
+		env[k] = value
+	}
+	return env
+}
+
+func (env Env) StringMap() map[string]string {
+	out := make(map[string]string, len(env))
+	for k, v := range env {
+		out[k] = v.Value
+	}
+	return out
+}
+
+func (env Env) Merge(src Env) Env {
+	if env == nil {
+		env = make(Env)
+	}
+	for k, v := range src {
+		env[k] = v
+	}
+	return env
+}
+
+func (env Env) Environ() []string {
+	out := make([]string, 0, len(env))
+	for k, v := range env {
+		if k != "" {
+			out = append(out, fmt.Sprintf("%s=%s", k, v.Value))
+		}
+	}
+	return out
+}
+
+func (env Env) Lines(showSecrets bool) []string {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	lines := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := env[k]
+		value := v.DisplayForKey(k, showSecrets)
+		lines = append(lines, fmt.Sprintf("%s=%s", k, value))
+	}
+	return lines
+}
+
+func LooksSensitiveName(key string) bool {
+	upper := strings.ToUpper(key)
+	for _, marker := range []string{"SECRET", "PASSWORD", "TOKEN", "_KEY", "API_KEY", "ACCESS_KEY", "PRIVATE_KEY"} {
+		if strings.Contains(upper, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v Value) Display(showSecrets bool) string {
+	if v.Secret && !showSecrets {
+		return RedactedValue
+	}
+	return v.Value
+}
+
+func (v Value) DisplayForKey(key string, showSecrets bool) string {
+	if (v.Secret || LooksSensitiveName(key)) && !showSecrets {
+		return RedactedValue
+	}
+	return v.Value
+}
+
+var expansionPattern = regexp.MustCompile(`\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?`)
+
+func expandValue(value string, env Env) (string, bool) {
+	usedSecret := false
+	expanded := expansionPattern.ReplaceAllStringFunc(value, func(match string) string {
+		parts := expansionPattern.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		key := parts[1]
+		if val, ok := env[key]; ok {
+			if val.Secret {
+				usedSecret = true
+			}
+			return val.Value
+		}
+		return os.Getenv(key)
+	})
+	return expanded, usedSecret
+}
+
+func isSecretRef(value string) (ref string, optional bool, ok bool) {
+	switch {
+	case strings.HasPrefix(value, "secret?:"):
+		return strings.TrimPrefix(value, "secret?:"), true, true
+	case strings.HasPrefix(value, "secret:"):
+		return strings.TrimPrefix(value, "secret:"), false, true
+	default:
+		return "", false, false
+	}
+}

--- a/envs/var.go
+++ b/envs/var.go
@@ -1,7 +1,9 @@
 package envs
 
 import (
+	"context"
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/ionrock/we/flat"
@@ -13,21 +15,42 @@ type Var struct {
 	dir   string
 }
 
-func (e Var) Apply() (map[string]string, error) {
-	parts := strings.Split(e.field, "=")
+func (e Var) Apply(cur Env) (Env, error) {
+	parts := strings.SplitN(e.field, "=", 2)
 	if len(parts) != 2 {
 		return nil, errors.New("Invalid env var format. Use %s=%s")
 	}
 	key := parts[0]
-	value := parts[1]
+	raw := parts[1]
 
-	value, err := process.CompileValue(value, e.dir)
+	raw, err := process.CompileValue(raw, e.dir)
 	if err != nil {
 		return nil, err
 	}
 
-	env := make(map[string]string)
-	flat.ApplyString(env, key, value)
+	// Preserve existing side effects for command substitution/expansion users.
+	legacy := make(map[string]string)
+	flat.ApplyString(legacy, key, raw)
 
+	expanded, usedSecret := expandValue(raw, cur)
+	env := make(Env)
+	if ref, optional, ok := isSecretRef(expanded); ok {
+		value, include, err := DefaultProviders().Resolve(context.Background(), ref, optional)
+		if err != nil {
+			return nil, err
+		}
+		if include {
+			value.Raw = raw
+			value.Source = "envvar"
+			env[key] = value
+			os.Setenv(key, value.Value)
+		}
+		return env, nil
+	}
+	value := NewLiteralValue(expanded, "envvar")
+	value.Raw = raw
+	value.Secret = usedSecret || LooksSensitiveName(key)
+	env[key] = value
+	os.Setenv(key, value.Value)
 	return env, nil
 }

--- a/flat/env.go
+++ b/flat/env.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strconv"
 	"strings"
 
@@ -15,8 +14,9 @@ import (
 )
 
 type FlatEnv struct {
-	Path string
-	Env  map[string]string
+	Path  string
+	Env   map[string]string
+	Order []string
 }
 
 func (env *FlatEnv) key(parts []string) (string, error) {
@@ -39,6 +39,8 @@ func (env *FlatEnv) addString(prefix []string, value string) error {
 
 	if _, ok := env.Env[key]; ok {
 		value = fmt.Sprintf("%s %s", env.Env[key], value)
+	} else {
+		env.Order = append(env.Order, key)
 	}
 	env.Env[key] = value
 	ApplyString(env.Env, key, value)
@@ -106,7 +108,7 @@ func (env *FlatEnv) Decode() (interface{}, error) {
 	return f, nil
 }
 
-func NewFlatEnv(path string) (map[string]string, error) {
+func NewFlatEnvWithOrder(path string) (map[string]string, []string, error) {
 	env := &FlatEnv{
 		Path: path,
 		Env:  make(map[string]string),
@@ -114,18 +116,26 @@ func NewFlatEnv(path string) (map[string]string, error) {
 
 	f, err := env.Decode()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	err = env.Load(f, []string{})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return env.Env, nil
+	return env.Env, env.Order, nil
+}
+
+func NewFlatEnv(path string) (map[string]string, error) {
+	env, _, err := NewFlatEnvWithOrder(path)
+	return env, err
 }
 
 func ApplyString(env map[string]string, key string, value string) {
-	env[key] = os.ExpandEnv(value)
-	os.Setenv(key, env[key])
-	log.Debug().Msgf("setting %s to %s", key, env[key])
+	env[key] = value
+	if strings.HasPrefix(env[key], "secret:") || strings.HasPrefix(env[key], "secret?:") {
+		log.Debug().Msgf("setting %s to <redacted>", key)
+	} else {
+		log.Debug().Msgf("setting %s to %s", key, env[key])
+	}
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Home: index.md
   - Quickstart: quickstart.md
   - Reference: reference.md
+  - Secrets: secrets.md
   - Advanced usage: advanced.md
 
 markdown_extensions:


### PR DESCRIPTION
## What?

Adds first-class secret reference support to `we` environment loading:

- Resolves `secret:` / `secret?:` scalar values before running the child command
- Adds built-in providers for 1Password (`op`), AWS Secrets Manager (`aws`), and Bitwarden (`bw`)
- Tracks secret metadata so `we` inspection/debug output can redact values
- Propagates secrecy to values expanded from secrets
- Documents provider syntax, examples, and current limitations

## Why?

This lets users keep API keys and other credentials in existing secret managers while still exposing them to commands through `we` as environment variables. It avoids committing or storing raw secret values in withenv files, while preserving the current explicit source model.

## Validation

- `mkdocs build --strict`
